### PR TITLE
fix: add package.json exports types

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "module": "./dist/vue-baidu-map-3x.es.js",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/vue-baidu-map-3x.es.js",
       "require": "./dist/vue-baidu-map-3x.umd.js"
     }


### PR DESCRIPTION
Fixes #47 

[The xxxx library may need to update its package.json or typings.ts](https://stackoverflow.com/questions/76211877/the-xxxx-library-may-need-to-update-its-package-json-or-typings-ts)

The `types` field in package.json is no longer used if there is an [exports](https://nodejs.org/api/packages.html#exports) field: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing